### PR TITLE
Adiciona field no campo isAdmin da migration que cria tabela employee e cria migration para adicionar superAdmin

### DIFF
--- a/migrations/20200317005011-create-employee-table.js
+++ b/migrations/20200317005011-create-employee-table.js
@@ -26,6 +26,7 @@ module.exports = {
       isAdmin: {
         type: Sequelize.BOOLEAN,
         allowNull: false,
+        field: 'is_admin',
       },
       createdAt: {
         type: Sequelize.DATE,

--- a/migrations/20200318231424-create-employee-data.js
+++ b/migrations/20200318231424-create-employee-data.js
@@ -1,0 +1,34 @@
+/**
+ * Bcrypt configs
+ *
+ * password: 12345678
+ * nº rounds: 12
+ */
+
+const hash = '$2b$12$nT/8GO9Ei1dPo0ylr6FD6e/rj.aQTheVl3/1AH3AZwyjz4hmvmDZC';
+
+module.exports = {
+  up: (queryInterface) => {
+    return queryInterface.bulkInsert('employee', [
+      {
+        id: 1,
+        login: 'superAdmin',
+        password: hash,
+        email: 'example@example.com',
+        full_name: 'Super Administrador',
+        is_admin: true,
+        created_At: new Date(),
+        updated_At: new Date(),
+        deleted_At: null,
+      },
+    ]);
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.bulkDelete('employee', {
+      id: {
+        [Sequelize.Op.in]: [1],
+      },
+    });
+  },
+};


### PR DESCRIPTION
É necessário a criação de um superAdmin por padrão no sistema pois esse usuário será responsável por cadastrar as demais contas de nível inferior.

É necessário que a criação de um superAdmin seja uma migration e não uma seed.